### PR TITLE
Track screens

### DIFF
--- a/glassyclock.cpp
+++ b/glassyclock.cpp
@@ -34,11 +34,11 @@
 
 namespace GlassyClock {
 
-GClock::GClock(int size, const QPoint pos, const QString &screenName , QWidget *parent)
+GClock::GClock(int size, const QPoint pos, QScreen *targetScreen, QWidget *parent)
   : QWidget(parent),
     size_(size),
     pos_(pos),
-    screenName_(screenName) {
+    targetScreen_(targetScreen) {
   /* WARNING: Setting "Qt::WindowDoesNotAcceptFocus" might disable
               global shortcuts if no other window is focused. */
   setWindowFlags(Qt::WindowTransparentForInput | Qt::FramelessWindowHint);
@@ -181,37 +181,17 @@ void GClock::showEvent(QShowEvent *event) {
     winId();
     if (QWindow* win = windowHandle()) {
       if (LayerShellQt::Window* layershell = LayerShellQt::Window::get(win)) {
+
         layershell->setLayer(LayerShellQt::Window::Layer::LayerBottom);
-        LayerShellQt::Window::Anchors anchors = {LayerShellQt::Window::AnchorTop
-                                                 | LayerShellQt::Window::AnchorLeft};
-        layershell->setAnchors(anchors);
+        layershell->setAnchors({LayerShellQt::Window::AnchorTop
+                                | LayerShellQt::Window::AnchorLeft});
         layershell->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityNone);
         layershell->setExclusiveZone(-1);
         layershell->setScope(QStringLiteral("glassyclock"));
 
         // screen
-        QScreen *_screen = nullptr;
-        auto screens = QGuiApplication::screens();
-        if (!screenName_.isEmpty()) {
-          for (const auto &screen : std::as_const(screens)) {
-            if (screen->name() == screenName_) {
-              _screen = screen;
-              break;
-            }
-          }
-        }
-        if (_screen == nullptr && !screens.isEmpty()) {
-          // find the leftmost or topmost screen
-          std::sort(screens.begin(), screens.end(), [](QScreen *a1, QScreen *a2) {
-            QPoint p1(a1->geometry().topLeft());
-            QPoint p2(a2->geometry().topLeft());
-            return (qAbs(p1.x() - p2.x()) > qAbs(p1.y() - p2.y()) ? p1.x() < p2.x()
-                                                                  : p1.y() < p2.y());
-          });
-          _screen = screens.at(0);
-        }
-        if (_screen != nullptr) {
-          win->setScreen(_screen);
+        if (targetScreen_ != nullptr) {
+          win->setScreen(targetScreen_);
           layershell->setScreenConfiguration(LayerShellQt::Window::ScreenConfiguration::ScreenFromQWindow);
         }
 

--- a/glassyclock.cpp
+++ b/glassyclock.cpp
@@ -61,6 +61,10 @@ GClock::~GClock() {
     KWindowEffects::enableBlurBehind(win, false);
 }
 
+QScreen *GClock::currentTargetScreen() const {
+  return targetScreen_;
+}
+
 void GClock::updateClock() {
   // ensure that the clock remains accurate within 250 milliseconds (also see paintEvent)
   int msec = QTime::currentTime().msec();

--- a/glassyclock.h
+++ b/glassyclock.h
@@ -30,7 +30,7 @@ class GClock : public QWidget {
   Q_OBJECT
 
 public:
-  GClock(int size = 0, const QPoint pos = QPoint(-1, -1), const QString &screenName = QString(), QWidget *parent = nullptr);
+  GClock(int size = 0, const QPoint pos = QPoint(-1, -1), QScreen *targetScreen = nullptr, QWidget *parent = nullptr);
   ~GClock();
 
   QSize sizeHint() const override;
@@ -46,7 +46,7 @@ private slots:
 private:
   int size_;
   QPoint pos_;
-  QString screenName_;
+  QScreen *targetScreen_;
   QSvgRenderer *renderer_;
   QTimer *timer_;
 };

--- a/glassyclock.h
+++ b/glassyclock.h
@@ -34,6 +34,7 @@ public:
   ~GClock();
 
   QSize sizeHint() const override;
+  QScreen *currentTargetScreen() const;
 
 protected:
   void paintEvent(QPaintEvent *event) override;

--- a/main.cpp
+++ b/main.cpp
@@ -21,8 +21,38 @@
 #include <QApplication>
 #include <QPoint>
 #include <QTextStream>
+#include <QGuiApplication>
+#include <QScreen>
 
 #include "glassyclock.h"
+
+QScreen* getTargetScreen(QString screenName) {
+  // Qt adds placeholder screens when no real screen is present
+  auto screens = QGuiApplication::screens();
+  screens.removeIf([](QScreen *screen) {
+    QRect geom = screen->geometry();
+    return geom.width() <= 0 || geom.height() <= 0;
+  });
+
+  if (screens.isEmpty())
+    return nullptr;
+
+  if (!screenName.isEmpty()) {
+    for (const auto &screen : screens)
+      if (screen->name() == screenName)
+        return screen;
+    return nullptr;
+  }
+
+  // Find the leftmost or topmost screen when no specific screen is requested
+  std::sort(screens.begin(), screens.end(), [](QScreen *a1, QScreen *a2) {
+    QPoint p1(a1->geometry().topLeft());
+    QPoint p2(a2->geometry().topLeft());
+    return (qAbs(p1.x() - p2.x()) > qAbs(p1.y() - p2.y()) ? p1.x() < p2.x()
+                                                          : p1.y() < p2.y());
+  });
+  return screens.at(0);
+}
 
 void handleQuitSignals(const std::vector<int>& quitSignals) {
   auto handler = [](int sig) ->void {
@@ -77,7 +107,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  GlassyClock::GClock clock(s, p, screenName);
+  GlassyClock::GClock clock(s, p, getTargetScreen(screenName));
   clock.show();
   return app.exec();
 }

--- a/main.cpp
+++ b/main.cpp
@@ -107,6 +107,7 @@ int main(int argc, char *argv[]) {
 
   QApplication app(argc, argv);
   app.setApplicationName(name);
+  app.setQuitOnLastWindowClosed(false);
   handleQuitSignals({SIGQUIT, SIGINT, SIGTERM, SIGHUP});
 
   if (argc > 1) {

--- a/main.cpp
+++ b/main.cpp
@@ -26,6 +26,12 @@
 
 #include "glassyclock.h"
 
+// Global variables for screen monitoring
+std::unique_ptr<GlassyClock::GClock> g_clock;
+int g_size = 0;
+QPoint g_pos(-1, -1);
+QString g_screenName;
+
 QScreen* getTargetScreen(QString screenName) {
   // Qt adds placeholder screens when no real screen is present
   auto screens = QGuiApplication::screens();
@@ -52,6 +58,24 @@ QScreen* getTargetScreen(QString screenName) {
                                                           : p1.y() < p2.y());
   });
   return screens.at(0);
+}
+
+void onScreenChanged(QScreen *screen) {
+  Q_UNUSED(screen);
+  QScreen* targetScreen = getTargetScreen(g_screenName);
+
+  if (g_clock && targetScreen == g_clock->currentTargetScreen())
+    return;
+
+  if (g_clock) {
+    g_clock->hide();
+    g_clock.reset();
+  }
+
+  if (targetScreen != nullptr) {
+    g_clock = std::make_unique<GlassyClock::GClock>(g_size, g_pos, targetScreen);
+    g_clock->show();
+  }
 }
 
 void handleQuitSignals(const std::vector<int>& quitSignals) {
@@ -85,29 +109,30 @@ int main(int argc, char *argv[]) {
   app.setApplicationName(name);
   handleQuitSignals({SIGQUIT, SIGINT, SIGTERM, SIGHUP});
 
-  int s = 0;
-  QPoint p(-1, -1);
-  QString screenName;
   if (argc > 1) {
     bool ok;
     int n = firstArg.toInt(&ok);
     if (ok) {
-      s = n;
+      g_size = n;
       if (argc > 3) {
         n = QString::fromUtf8(argv[2]).toInt(&ok);
         if (ok) {
-          p.setX(n);
+          g_pos.setX(n);
           n = QString::fromUtf8(argv[3]).toInt(&ok);
           if (ok)
-            p.setY(n);
+            g_pos.setY(n);
         }
         if (argc > 4) {
-          screenName = QString::fromUtf8(argv[4]);
+          g_screenName = QString::fromUtf8(argv[4]);
         }
       }
     }
   }
-  GlassyClock::GClock clock(s, p, getTargetScreen(screenName));
-  clock.show();
+
+  QObject::connect(qobject_cast<QGuiApplication*>(&app), &QGuiApplication::screenAdded, onScreenChanged);
+  QObject::connect(qobject_cast<QGuiApplication*>(&app), &QGuiApplication::screenRemoved, onScreenChanged);
+
+  // We don't get any event for the intial screens it seems, just trigger it once
+  onScreenChanged(nullptr);
   return app.exec();
 }


### PR DESCRIPTION
Just out of curiosity I took a look at what layer-shell-qt required to track screen changes and keep running.

It ended up not requiring much, other than moving some logic around and subscribing to the screen events. Seems to work, although I only briefly tested the wayland side of things.

As a bonus, when not configured to use a specific screen it'll now move to stay on the at any time best candidate screen.